### PR TITLE
RABSW-963 Adjust rabbit repos for nnf-sanitized lustre-csi-driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/NearNodeFlash/lustre-fs-operator
 
 go 1.16
 
+replace github.com/HewlettPackard/lustre-csi-driver => ../lustre-csi-driver
+
 require (
 	github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220516192757-17ac28565db5
 	github.com/go-logr/logr v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,8 @@ module github.com/NearNodeFlash/lustre-fs-operator
 
 go 1.16
 
-replace github.com/HewlettPackard/lustre-csi-driver => ../lustre-csi-driver
-
 require (
-	github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220516192757-17ac28565db5
+	github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95
 	github.com/go-logr/logr v0.4.0
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220516192757-17ac28565db5 h1:t+W1/ma3U4s8Ct4UVfUO+ZHVuytflXuQ7qJJwBre5kE=
-github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220516192757-17ac28565db5/go.mod h1:Wwr96QYACIixBjBXpST9yMS81WxMu/tF/zc/5OW21Dk=
+github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95 h1:5neutLfJ4zWKHLeYw+a1EfW2veMC3sI50RNvgfeax9Q=
+github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95/go.mod h1:Wwr96QYACIixBjBXpST9yMS81WxMu/tF/zc/5OW21Dk=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/vendor/github.com/HewlettPackard/lustre-csi-driver/pkg/lustre-driver/service/service.go
+++ b/vendor/github.com/HewlettPackard/lustre-csi-driver/pkg/lustre-driver/service/service.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// Name is the name of this CSI SP.
-	Name = "lustre-csi.nnf.cray.hpe.com"
+	Name = "lustre-csi.hpe.com"
 
 	// VendorVersion is the version of this CSP SP.
 	VendorVersion = "v0.0.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -13,7 +13,7 @@ github.com/Azure/go-autorest/autorest/date
 github.com/Azure/go-autorest/logger
 # github.com/Azure/go-autorest/tracing v0.6.0
 github.com/Azure/go-autorest/tracing
-# github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220516192757-17ac28565db5
+# github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95
 ## explicit
 github.com/HewlettPackard/lustre-csi-driver/pkg/lustre-driver/service
 # github.com/beorn7/perks v1.0.1


### PR DESCRIPTION
In KJPLAT-541 the lustre-csi-driver is being sanitized of any references to
rabbit or nnf. Other rabbit repos must be adjusted for this.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>