### PR TITLE
Immutable Error: change from Invalid to Forbidden

### DIFF
--- a/api/v1alpha1/lustrefilesystem_webhook.go
+++ b/api/v1alpha1/lustrefilesystem_webhook.go
@@ -120,22 +120,24 @@ func (r *LustreFileSystem) ValidateUpdate(obj runtime.Object) error {
 	old := obj.(*LustreFileSystem)
 
 	// Prevent the immutable fields from being updated
-	specPath := field.NewPath("Spec")
+	immutableError := func(child string) error {
+		return field.Forbidden(field.NewPath("Spec").Child(child), "field is immutable")
+	}
 
 	if r.Spec.Name != old.Spec.Name {
-		return field.Invalid(specPath.Child("Name"), r.Spec.Name, "field is immutable")
+		return immutableError("Name")
 	}
 
 	if r.Spec.MgsNids != old.Spec.MgsNids {
-		return field.Invalid(specPath.Child("MgsNids"), r.Spec.MgsNids, "field is immutable")
+		return immutableError("MgsNids")
 	}
 
 	if r.Spec.MountRoot != old.Spec.MountRoot {
-		return field.Invalid(specPath.Child("MountRoot"), r.Spec.MountRoot, "field is immutable")
+		return immutableError("MountRoot")
 	}
 
 	if r.Spec.StorageClassName != old.Spec.StorageClassName {
-		return field.Invalid(specPath.Child("StorageClassName"), r.Spec.StorageClassName, "field is immutable")
+		return immutableError("StorageClassName")
 	}
 
 	return nil


### PR DESCRIPTION
This follows Tony's recent code change in [dws](https://github.com/HewlettPackard/dws/pull/66)

`Invalid` is used to report malformed values; where as `Forbidden` is used to report valid values, but which are not permitted by current condition.

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>