### PR TITLE
Remove reliance on cray.nnf.manager node label.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ docker-push: .version ## Push docker image with the manager.
 
 kind-push: VERSION ?= $(shell cat .version)
 kind-push: .version
-	kind load docker-image --nodes `kubectl get nodes -l cray.nnf.manager=true -o json | jq -rM '.items[].metadata.name' | paste -d, -s -` $(IMAGE_TAG_BASE):$(VERSION)
+	kind load docker-image $(IMAGE_TAG_BASE):$(VERSION)
 
 ##@ Deployment
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -22,8 +22,6 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      nodeSelector:
-        cray.nnf.manager: "true"
       securityContext:
         runAsNonRoot: true
       containers:


### PR DESCRIPTION
This should just go to an available untainted worker node.