### PR TITLE
Allow installation with the -k arg to kubectl apply

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,12 +6,32 @@ Before opening an issue or pull request, please read the [Contributing] guide.
 
 [contributing]: CONTRIBUTING.md
 
-## Bootstrapping
+## Installing
 
-This operator was boostrapped using the operator-sdk
+Install on a Rabbit system with:
+```console
+kubectl apply -k 'https://github.com/NearNodeFlash/lustre-fs-operator.git/config/default/?ref=master'
+```
 
-```bash
-operator-sdk init --domain cray.hpe.com --repo github.com/NearNodeFlash/lustre-fs-operator
-operator-sdk create api --version v1alpha1 --kind LustreFileSystem --resource --controller
-operator-sdk create webhook --version v1alpha1 --kind LustreFileSystem --programmatic-validation
+Install a specific release with:
+```console
+kubectl apply -k 'https://github.com/NearNodeFlash/lustre-fs-operator.git/config/default/?ref=v0.0.1'
+```
+
+## Making a release
+
+When making a release, set the image tag in the kustomization configuration
+with the following and commit the new kustomization.yaml to the release branch.
+This will allow the above `kubectl apply -k` commands to work with that
+release, ensuring that when installed, the pods will pull the same container
+tag.
+
+Note that for a release of "v0.0.2", we specify it without the leading "v":
+```console
+make installer VERSION=0.0.2
+```
+
+The `master` branch should always point to the `master` tag.  This can always be reset with:
+```console
+make installer VERSION=master
 ```

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,4 +18,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/nearnodeflash/lustre-fs-operator
-  newTag: 0.0.1
+  newTag: master


### PR DESCRIPTION
Set the default image tag to 'master' so it tracks containers built on the master branch.

For release branches we'll use the included instructions to set the image tag to that release so it pulls its matching container.