### PR TITLE
Dynamically create an overlay for the image tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 bin
 testbin/*
 .version
+config/begin/*
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ docker-build: .version ## Build docker image with the manager.
 
 edit-image: VERSION ?= $(shell cat .version)
 edit-image: .version kustomize ## Replace manager/kustomization.yaml image with name "controller" -> ghcr tagged container reference
-	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMAGE_TAG_BASE):$(VERSION)
+	$(KUSTOMIZE_IMAGE_TAG) config/begin default $(IMAGE_TAG_BASE) $(VERSION)
 
 docker-push: VERSION ?= $(shell cat .version)
 docker-push: .version ## Push docker image with the manager.
@@ -205,9 +205,9 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found -f -
 
 deploy: kustomize edit-image ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	$(KUSTOMIZE) build config/begin | kubectl apply -f -
 
-undeploy: kustomize edit-image ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
+undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found -f -
 
 installer: kustomize edit-image
@@ -233,6 +233,7 @@ clean-bin:
 	fi
 
 ## Tool Binaries
+KUSTOMIZE_IMAGE_TAG ?= ./hack/make-kustomization.sh
 GO_INSTALL := ./github/cluster-api/scripts/go_install.sh
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen

--- a/hack/make-kustomization.sh
+++ b/hack/make-kustomization.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Copyright 2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+OVERLAY_DIR=$1
+OVERLAY=$2
+IMAGE_TAG_BASE=$3
+TAG=$4
+
+if [[ ! -d $OVERLAY_DIR ]]
+then
+    mkdir "$OVERLAY_DIR"
+fi
+
+cat <<EOF > "$OVERLAY_DIR"/kustomization.yaml
+resources:
+- ../$OVERLAY
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: $IMAGE_TAG_BASE
+  newTag: $TAG
+EOF
+


### PR DESCRIPTION
Avoid editing config/manager/kustomization.yaml to set the image tag.  This causes git to consider the workarea to be dirty, so two consecutive deploys from a workarea that has no other changes will result in the second deploy looking for an image with a "-dirty" tag.

Instead, from the makefile we create a throw-away, and untracked, overlay that will be used to set the image tag.