### PR TITLE
Update the project for kubebuilder go/v4 layout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,21 @@
+#
+# Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# Other additional copyright holders may be indicated within.
+#
+# The entirety of this work is licensed under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Build the manager binary
 FROM golang:1.19 as builder
 
@@ -6,13 +24,13 @@ WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
 COPY vendor/ vendor/
-COPY main.go main.go
+COPY cmd/ cmd/
 COPY api/ api/
-COPY controllers/ controllers/
+COPY internal/ internal/
 COPY github/cluster-api/util/conversion/ github/cluster-api/util/conversion/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/main.go
 
 FROM builder as testing
 WORKDIR /workspace

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 # Explicitly specifying directories to test here to avoid running tests in .dws-operator for the time being.
-# ./controllers/...
+# ./internal/...
 # ./api/...
 # Below is a list of ginkgo test flags that may be used to generate different test patterns.
 # Specifying 'count=1' is the idiomatic way to disable test caching
@@ -168,17 +168,17 @@ container-unit-test: .version ## Build docker image with the manager and execute
 	${DOCKER} build -f Dockerfile --label $(IMAGE_TAG_BASE)-$@:$(VERSION)-$@ -t $(IMAGE_TAG_BASE)-$@:$(VERSION) --target testing .
 	${DOCKER} run --rm -t --name $@-lustre-fs-operator $(IMAGE_TAG_BASE)-$@:$(VERSION)
 
-TESTDIR ?= ./controllers/... ./api/...
+TESTDIR ?= ./internal/... ./api/...
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(LOCALBIN))" go test $(TESTDIR) -coverprofile cover.out -args -ginkgo.v
 
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/manager main.go
+	go build -o bin/manager cmd/main.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go
+	go run cmd/main.go
 
 docker-build: VERSION ?= $(shell cat .version)
 docker-build: .version ## Build docker image with the manager.

--- a/PROJECT
+++ b/PROJECT
@@ -4,7 +4,7 @@
 # More info: https://book.kubebuilder.io/reference/project-config.html
 domain: cray.hpe.com
 layout:
-- go.kubebuilder.io/v3
+- go.kubebuilder.io/v4
 plugins:
   manifests.sdk.operatorframework.io/v2: {}
   scorecard.sdk.operatorframework.io/v2: {}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,7 +37,7 @@ import (
 
 	lusv1alpha1 "github.com/NearNodeFlash/lustre-fs-operator/api/v1alpha1"
 	lusv1beta1 "github.com/NearNodeFlash/lustre-fs-operator/api/v1beta1"
-	"github.com/NearNodeFlash/lustre-fs-operator/controllers"
+	controllers "github.com/NearNodeFlash/lustre-fs-operator/internal/controller"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/NearNodeFlash/lustre-fs-operator
 
 go 1.19
 
+replace github.com/DataWorkflowServices/dws => ../dws
+
 require (
 	github.com/DataWorkflowServices/dws v0.0.1-0.20231010162938-b6d65b00cad6
 	github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,8 @@ module github.com/NearNodeFlash/lustre-fs-operator
 
 go 1.19
 
-replace github.com/DataWorkflowServices/dws => ../dws
-
 require (
-	github.com/DataWorkflowServices/dws v0.0.1-0.20231010162938-b6d65b00cad6
+	github.com/DataWorkflowServices/dws v0.0.1-0.20231031201121-13a5a69a969e
 	github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95
 	github.com/google/go-cmp v0.5.9
 	github.com/google/gofuzz v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/DataWorkflowServices/dws v0.0.1-0.20231010162938-b6d65b00cad6 h1:+j1ex3+PaJApQzCR7reMIJULPL+a7uOHYRJdSQVRWhA=
-github.com/DataWorkflowServices/dws v0.0.1-0.20231010162938-b6d65b00cad6/go.mod h1:grHFCu0CoUK8exzS57r6cdf4qHpG1Pv5nl0n7evpaUM=
 github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95 h1:5neutLfJ4zWKHLeYw+a1EfW2veMC3sI50RNvgfeax9Q=
 github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95/go.mod h1:Wwr96QYACIixBjBXpST9yMS81WxMu/tF/zc/5OW21Dk=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DataWorkflowServices/dws v0.0.1-0.20231031201121-13a5a69a969e h1:QhDrVNQ6zyJcnP0+I147Ei19QAoOL5sDvkjNTkRbELA=
+github.com/DataWorkflowServices/dws v0.0.1-0.20231031201121-13a5a69a969e/go.mod h1:grHFCu0CoUK8exzS57r6cdf4qHpG1Pv5nl0n7evpaUM=
 github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95 h1:5neutLfJ4zWKHLeYw+a1EfW2veMC3sI50RNvgfeax9Q=
 github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95/go.mod h1:Wwr96QYACIixBjBXpST9yMS81WxMu/tF/zc/5OW21Dk=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=

--- a/internal/controller/conversion_test.go
+++ b/internal/controller/conversion_test.go
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package controllers
+package controller
 
 import (
 	"context"

--- a/internal/controller/lustrefilesystem_controller.go
+++ b/internal/controller/lustrefilesystem_controller.go
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package controllers
+package controller
 
 import (
 	"context"

--- a/internal/controller/lustrefilesystem_controller_test.go
+++ b/internal/controller/lustrefilesystem_controller_test.go
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package controllers
+package controller
 
 import (
 	"context"

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-package controllers
+package controller
 
 import (
 	"context"
@@ -79,9 +79,9 @@ var _ = BeforeSuite(func() {
 
 	testEnv = &envtest.Environment{
 		WebhookInstallOptions: envtest.WebhookInstallOptions{Paths: []string{
-			filepath.Join("..", "config", "webhook"),
+			filepath.Join("..", "..", "config", "webhook"),
 		}},
-		CRDDirectoryPaths:        []string{filepath.Join("..", "config", "crd", "bases")},
+		CRDDirectoryPaths:        []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing:    true,
 		AttachControlPlaneOutput: true,
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/DataWorkflowServices/dws v0.0.1-0.20231010162938-b6d65b00cad6
+# github.com/DataWorkflowServices/dws v0.0.1-0.20231010162938-b6d65b00cad6 => ../dws
 ## explicit; go 1.19
 github.com/DataWorkflowServices/dws/utils/updater
 # github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95
@@ -719,3 +719,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# github.com/DataWorkflowServices/dws => ../dws

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/DataWorkflowServices/dws v0.0.1-0.20231010162938-b6d65b00cad6 => ../dws
+# github.com/DataWorkflowServices/dws v0.0.1-0.20231031201121-13a5a69a969e
 ## explicit; go 1.19
 github.com/DataWorkflowServices/dws/utils/updater
 # github.com/HewlettPackard/lustre-csi-driver v0.0.0-20220623192103-4ce53adacc95
@@ -719,4 +719,3 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# github.com/DataWorkflowServices/dws => ../dws


### PR DESCRIPTION
Change the layout to follow the Standard Go Project Layout, as described in https://book.kubebuilder.io/migration/v3vsv4.  This allows newer releases of kubebuilder to be used with this repo.