### PR TITLE
Add a check for only lustrefilesystem finalizer before delete

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "go",
             "request": "launch",
             "mode": "test",
-            "program": "${workspaceFolder}/controllers",
+            "program": "${workspaceFolder}/internal/controller",
             "args": [
                 "-ginkgo.v",
                 "-ginkgo.progress",

--- a/internal/controller/lustrefilesystem_controller.go
+++ b/internal/controller/lustrefilesystem_controller.go
@@ -95,10 +95,9 @@ func (r *LustreFileSystemReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return false
 		}
 
-		// At this point, only our finalizer should be present before access is deleted. If not,
-		// requeue until they are gone.
+		// At this point, only our finalizer should be present before access is deleted.
 		if !onlyLustreFinalizer(fs) {
-			return ctrl.Result{Requeue: true}, nil
+			return ctrl.Result{}, nil
 		}
 
 		for namespace := range fs.Spec.Namespaces {


### PR DESCRIPTION
This ensures that the PV/PVC cannot be removed while something is still
using it (e.g. NNF Data Movement).

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
