### PR TITLE
Add watch for namespaces

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumeclaims
   verbs:
   - create

--- a/internal/controller/lustrefilesystem_controller.go
+++ b/internal/controller/lustrefilesystem_controller.go
@@ -139,7 +139,11 @@ func (r *LustreFileSystemReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// If the namespace doesn't exist, set a flag so that we can appropriately set the status in the mode loop
 		ns := &corev1.Namespace{}
 		if err := r.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
-			namespacePresent = false
+			if errors.IsNotFound(err) {
+				namespacePresent = false
+			} else {
+				return ctrl.Result{}, err
+			}
 		}
 
 		// Create the Status Namespace map if empty


### PR DESCRIPTION
The Lustrefilesystem resource can get into odd situations when
namespaces are deleted. This leads to stale data in the Spec/Status
fields since nothing changes in the spec and no operator reconcile
occurs. Once this happens, PVCs will not be recreated once the namespace
comes back. This can happen when undeploying and redeploying nnf-dm when
a lustrefilesystem resource is active.

To remedy this, any change in namespaces (e.g. when nnf-dm is deployed
and the namespace is created) will trigger the reconciler and any
missing PV/PVCS will then be created.

Tested by:
1. Created a lustrefilesystem resource
2. nnf-dm then automatically adds itself to the list of namespaces in
   that resource
3. Undeploy nnf-dm (and delete namespace) - this removes the PVC
4. Redeploy nnf-dm - the PVC will be recreated mounted
