### PR TITLE
Harden deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -18,6 +18,7 @@
 # limitations under the License.
 
 set -e
+set -o pipefail
 
 # Deploy/undeploy controller to the K8s cluster specified in ~/.kube/config.
 
@@ -26,7 +27,7 @@ KUSTOMIZE=$2
 OVERLAY_DIR=$3
 
 if [[ $CMD == 'deploy' ]]; then
-    $KUSTOMIZE build $OVERLAY_DIR | kubectl apply -f -
+    $KUSTOMIZE build "$OVERLAY_DIR" | kubectl apply -f -
 
     # Deploy the ServiceMonitor resource if its CRD is found. The CRD would
     # have been installed by a metrics service such as Prometheus.
@@ -40,7 +41,7 @@ if [[ $CMD == 'undeploy' ]]; then
         $KUSTOMIZE build config/prometheus | kubectl delete --ignore-not-found -f-
     fi
     # Do not touch the namespace resource when deleting this service.
-    $KUSTOMIZE build $OVERLAY_DIR | yq eval 'select(.kind != "Namespace")' |  kubectl delete --ignore-not-found -f -
+    $KUSTOMIZE build "$OVERLAY_DIR" | yq eval 'select(.kind != "Namespace")' |  kubectl delete --ignore-not-found -f -
 fi
 
 exit 0


### PR DESCRIPTION
If a tool is not found, such as yq in the middle of a pipeline, then we want the script to fail.
Also quiet some shellcheck warnings.