### PR TITLE
Add version labels to release manifest Deployment/DaemonSet

### DIFF
--- a/hack/make-kustomization.sh
+++ b/hack/make-kustomization.sh
@@ -29,24 +29,43 @@ then
     mkdir "$OVERLAY_DIR"
 fi
 
+COMPONENT_LABELS="
+    - op: add
+      path: /metadata/labels/app.kubernetes.io~1version
+      value: "$TAG"
+    - op: add
+      path: /metadata/labels/app.kubernetes.io~1component
+      value: lustre-fs-operator
+"
+
+NNF_VER_LABELS=""
+if [[ -n $NNF_VERSION ]]
+then
+    NNF_VER_LABELS="
+    - op: add
+      path: /metadata/labels/app.kubernetes.io~1nnf-version
+      value: "$NNF_VERSION"
+    - op: add
+      path: /metadata/labels/app.kubernetes.io~1part-of
+      value: nnf
+"
+fi
+
 cat <<EOF > "$OVERLAY_DIR"/kustomization.yaml
 resources:
 - ../$OVERLAY
 
-commonLabels:
-  app.kubernetes.io/version: "$TAG"
-  app.kubernetes.io/component: lustre-fs-operator
-EOF
-
-if [[ -n $NNF_VERSION ]]
-then
-    cat <<EOF >> "$OVERLAY_DIR"/kustomization.yaml
-  app.kubernetes.io/nnf-version: "$NNF_VERSION"
-  app.kubernetes.io/part-of: nnf
-EOF
-fi
-
-cat <<EOF >> "$OVERLAY_DIR"/kustomization.yaml
+patches:
+- target:
+    kind: Deployment
+  patch: |-
+$COMPONENT_LABELS
+$NNF_VER_LABELS
+- target:
+    kind: DaemonSet
+  patch: |-
+$COMPONENT_LABELS
+$NNF_VER_LABELS
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
Change make-kustomization.sh to add component/version labels only to Deployment/Daemonset in the manifest. By doing only these resources, rather than all resources, we minimize the noise in a manifest update to the gitops repo.

If run locally the labels will be:

  app.kubernetes.io/component: lustre-fs-operator
  app.kubernetes.io/version: <git-version-gen>

If run from nnf-deploy's "make manifests" the labels will be:

  app.kubernetes.io/component: lustre-fs-operator
  app.kubernetes.io/version: <lustre-fs-operator's git-version-gen>
  app.kubernetes.io/part-of: nnf
  app.kubernetes.io/nnf-version: <nnf-deploy's git-version-gen>