### PR TITLE
Add comment markers for the crd-bumper tool

### DIFF
--- a/github/cluster-api/util/conversion/conversion_test.go
+++ b/github/cluster-api/util/conversion/conversion_test.go
@@ -29,17 +29,19 @@ import (
 )
 
 var (
-	oldGVK = schema.GroupVersionKind{
+	oldLustreFileSystemGVK = schema.GroupVersionKind{
 		Group:   lusv1beta1.GroupVersion.Group,
 		Version: "v1old",
 		Kind:    "LustreFileSystem",
 	}
+
+	// +crdbumper:scaffold:gvk
 )
 
 func TestMarshalData(t *testing.T) {
 	g := NewWithT(t)
 
-	t.Run("should write source object to destination", func(*testing.T) {
+	t.Run("LustreFileSystem should write source object to destination", func(*testing.T) {
 		src := &lusv1beta1.LustreFileSystem{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-1",
@@ -55,7 +57,7 @@ func TestMarshalData(t *testing.T) {
 		}
 
 		dst := &unstructured.Unstructured{}
-		dst.SetGroupVersionKind(oldGVK)
+		dst.SetGroupVersionKind(oldLustreFileSystemGVK)
 		dst.SetName("test-1")
 
 		g.Expect(MarshalData(src, dst)).To(Succeed())
@@ -69,7 +71,7 @@ func TestMarshalData(t *testing.T) {
 		g.Expect(dst.GetAnnotations()[DataAnnotation]).To(ContainSubstring("/lus/w0"))
 	})
 
-	t.Run("should append the annotation", func(*testing.T) {
+	t.Run("LustreFileSystem should append the annotation", func(*testing.T) {
 		src := &lusv1beta1.LustreFileSystem{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-1",
@@ -85,19 +87,21 @@ func TestMarshalData(t *testing.T) {
 		g.Expect(MarshalData(src, dst)).To(Succeed())
 		g.Expect(dst.GetAnnotations()).To(HaveLen(2))
 	})
+
+	// +crdbumper:scaffold:marshaldata
 }
 
 func TestUnmarshalData(t *testing.T) {
 	g := NewWithT(t)
 
-	t.Run("should return false without errors if annotation doesn't exist", func(*testing.T) {
+	t.Run("LustreFileSystem should return false without errors if annotation doesn't exist", func(*testing.T) {
 		src := &lusv1beta1.LustreFileSystem{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-1",
 			},
 		}
 		dst := &unstructured.Unstructured{}
-		dst.SetGroupVersionKind(oldGVK)
+		dst.SetGroupVersionKind(oldLustreFileSystemGVK)
 		dst.SetName("test-1")
 
 		ok, err := UnmarshalData(src, dst)
@@ -105,9 +109,9 @@ func TestUnmarshalData(t *testing.T) {
 		g.Expect(err).ToNot(HaveOccurred())
 	})
 
-	t.Run("should return true when a valid annotation with data exists", func(*testing.T) {
+	t.Run("LustreFileSystem should return true when a valid annotation with data exists", func(*testing.T) {
 		src := &unstructured.Unstructured{}
-		src.SetGroupVersionKind(oldGVK)
+		src.SetGroupVersionKind(oldLustreFileSystemGVK)
 		src.SetName("test-1")
 		src.SetAnnotations(map[string]string{
 			DataAnnotation: "{\"metadata\":{\"name\":\"test-1\",\"creationTimestamp\":null,\"labels\":{\"label1\":\"\"}},\"spec\":{},\"status\":{}}",
@@ -129,9 +133,9 @@ func TestUnmarshalData(t *testing.T) {
 		g.Expect(dst.GetAnnotations()).To(BeEmpty())
 	})
 
-	t.Run("should clean the annotation on successful unmarshal", func(*testing.T) {
+	t.Run("LustreFileSystem should clean the annotation on successful unmarshal", func(*testing.T) {
 		src := &unstructured.Unstructured{}
-		src.SetGroupVersionKind(oldGVK)
+		src.SetGroupVersionKind(oldLustreFileSystemGVK)
 		src.SetName("test-1")
 		src.SetAnnotations(map[string]string{
 			"annotation-1": "",
@@ -151,6 +155,8 @@ func TestUnmarshalData(t *testing.T) {
 		g.Expect(src.GetAnnotations()).ToNot(HaveKey(DataAnnotation))
 		g.Expect(src.GetAnnotations()).To(HaveLen(1))
 	})
+
+	// +crdbumper:scaffold:unmarshaldata
 }
 
 // Just touch ginkgo, so it's here to interpret any ginkgo args from

--- a/internal/controller/conversion_test.go
+++ b/internal/controller/conversion_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2023-2024 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -75,7 +75,7 @@ var _ = Describe("Conversion Webhook Test", func() {
 			}
 		})
 
-		It("reads LustreFileSystem resource via hub and via spoke", func() {
+		It("reads LustreFileSystem resource via hub and via spoke v1alpha1", func() {
 			// Spoke should have annotation.
 			resSpoke := &lusv1alpha1.LustreFileSystem{}
 			Eventually(func(g Gomega) {
@@ -92,5 +92,9 @@ var _ = Describe("Conversion Webhook Test", func() {
 				g.Expect(anno).To(HaveLen(0))
 			}).Should(Succeed())
 		})
+
+		// +crdbumper:scaffold:spoketest="lus.LustreFileSystem"
 	})
+
+	// +crdbumper:scaffold:webhooksuitetest
 })

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+ * Copyright 2021-2024 Hewlett Packard Enterprise Development LP
  * Other additional copyright holders may be indicated within.
  *
  * The entirety of this work is licensed under the Apache License,
@@ -119,6 +119,8 @@ var _ = BeforeSuite(func() {
 
 	err = (&lusv1beta1.LustreFileSystem{}).SetupWebhookWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
+
+	// +crdbumper:scaffold:builder
 
 	err = (&LustreFileSystemReconciler{
 		Client: k8sManager.GetClient(),


### PR DESCRIPTION
This tool uses "marker comments" in the Go code to indicate where generated code should be placed.  These markers are used the same way `controller-gen` uses code markers.